### PR TITLE
Fix TypeError on raise exception (not found BeautifulSoup module)

### DIFF
--- a/pycorreios/correios.py
+++ b/pycorreios/correios.py
@@ -20,7 +20,7 @@ from xml.dom import minidom
 try:
     from BeautifulSoup import BeautifulSoup
 except ImportError:
-    raise 'Você não tem o modulo BeautifulSoup', ImportError
+    raise Exception('Você não tem o modulo BeautifulSoup', ImportError)
 
 
 class Correios(object):


### PR DESCRIPTION
When i ran the tests i found this error. This error occurs only if you don't have BeautifulSoup module installed:

TypeError:exceptions must be old-style classes or derived from BaseException, not str


